### PR TITLE
Adds additional arguments to bind function, as the pusher bind supports it

### DIFF
--- a/libs/libs.js
+++ b/libs/libs.js
@@ -135,9 +135,11 @@ Example:
     this.global_callbacks = [];
   }
 
-  EventsDispatcher.prototype.bind = function(event_name, callback) {
+  EventsDispatcher.prototype.bind = function(event_name, callback, data) {
     this.callbacks[event_name] = this.callbacks[event_name] || [];
-    this.callbacks[event_name].push(callback);
+    this.callbacks[event_name].push(function() {
+      callback.apply(data, arguments);
+    });
     return this;// chainable
   };
 


### PR DESCRIPTION
First off, thanks for the pusher-test-stub api, made testing a lot easier.

Found that the bind function in pusher api allows to bind a hash in the context of callback. In our site we are currently using the bind function as below: pusherChannel.bind(currentPusherEvent, pusherCallback, {url: url}); the last argument {url:url} is made accessible in pusherCallback function as this.url. Found that this is missing in the pusher-test-stub code.