### PR TITLE
Stub out  for members.get

### DIFF
--- a/build/bin/pusher-test-stub.js
+++ b/build/bin/pusher-test-stub.js
@@ -318,6 +318,14 @@ com.pusher.define("com.pusher.test.framework", function(exports) {
     }
   };
 
+  /**
+   * Getter method to access team member
+   * @param {Integer} Id of the member
+   */
+  Members.prototype.get = function(id) {
+    return this._members[id];
+  };
+
   exports.Pusher = Pusher;
   exports.Members = Members;
 });


### PR DESCRIPTION
As per https://pusher.com/docs/client_api_guide/client_presence_channels, there is a method `members.get` which was missing from the stub library